### PR TITLE
Fix coords at F_warpDie related to conquest mode

### DIFF
--- a/server/npc/eBG/bg_functions.txt
+++ b/server/npc/eBG/bg_functions.txt
@@ -564,7 +564,7 @@ function	script	F_warpDie	{
 										 28, 50,
 										 30, 381,
 										298, 339,
-										328, 154;
+										313, 154;
 
 			setarray .@CroixXY[0],	295, 379,
 									113, 311,


### PR DESCRIPTION
When $bg_conquest_rotate was 5 F_warpDie were warping both teams at the same "safe zone" (.@GuillotineXY array: 328, 154 and .@CroixXY array: 330, 154).
